### PR TITLE
Atualiza interface para tons azuis e brancos

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,11 +10,18 @@ class MainMenu(tk.Tk):
         super().__init__()
         self.title("Menu")
         self.resizable(False, False)
-        self.configure(padx=20, pady=20)
+        self.configure(padx=20, pady=20, bg='white')
 
-        tk.Button(self, text="Calculadora", width=15, command=self.open_calculator, font=('Arial', 14)).pack(pady=10)
-        tk.Button(self, text="Timer", width=15, command=self.open_timer, font=('Arial', 14)).pack(pady=10)
-        tk.Button(self, text="Cron\u00f4metro", width=15, command=self.open_stopwatch, font=('Arial', 14)).pack(pady=10)
+        btn_opts = {
+            "width": 15,
+            "font": ("Arial", 14),
+            "bg": "#d0e7ff",
+            "activebackground": "#a0cfff",
+        }
+
+        tk.Button(self, text="Calculadora", command=self.open_calculator, **btn_opts).pack(pady=10)
+        tk.Button(self, text="Timer", command=self.open_timer, **btn_opts).pack(pady=10)
+        tk.Button(self, text="Cronômetro", command=self.open_stopwatch, **btn_opts).pack(pady=10)
 
     def open_calculator(self):
         Calculator(self)

--- a/calculator.py
+++ b/calculator.py
@@ -6,12 +6,19 @@ class Calculator(tk.Toplevel):
     def __init__(self, master=None):
         super().__init__(master)
         self.title("Calculadora")
-        self.configure(bg='lightgray')
+        self.configure(bg='white')
         self.resizable(False, False)
 
         self.expression = ""
 
-        self.entry = tk.Entry(self, font=('Arial', 20), bd=5, relief=tk.RIDGE, justify='right')
+        self.entry = tk.Entry(
+            self,
+            font=('Arial', 20),
+            bd=5,
+            relief=tk.RIDGE,
+            justify='right',
+            bg='white',
+        )
         self.entry.grid(row=0, column=0, columnspan=4, padx=10, pady=10, ipady=10)
 
         buttons = [
@@ -21,24 +28,28 @@ class Calculator(tk.Toplevel):
             ('0', 4, 0), ('.', 4, 1), ('=', 4, 2), ('+', 4, 3),
         ]
 
+        btn_opts = {
+            "width": 5,
+            "height": 2,
+            "font": ('Arial', 18),
+            "bg": '#d0e7ff',
+            "activebackground": '#a0cfff',
+        }
+
         for (text, row, column) in buttons:
             action = partial(self.on_button_click, text)
             tk.Button(
                 self,
                 text=text,
-                width=5,
-                height=2,
-                font=('Arial', 18),
-                command=action
+                command=action,
+                **btn_opts,
             ).grid(row=row, column=column, padx=5, pady=5)
 
         tk.Button(
             self,
             text='C',
-            width=5,
-            height=2,
-            font=('Arial', 18),
-            command=self.clear
+            command=self.clear,
+            **btn_opts,
         ).grid(row=5, column=0, columnspan=4, padx=5, pady=5, sticky='we')
 
     def on_button_click(self, char):

--- a/stopwatch.py
+++ b/stopwatch.py
@@ -8,20 +8,33 @@ class Stopwatch(tk.Toplevel):
         super().__init__(master)
         self.title("Cron\u00f4metro")
         self.resizable(False, False)
+        self.configure(bg="white")
 
         self.elapsed = 0
         self.running = False
         self.after_id = None
 
-        self.label = tk.Label(self, text="00:00:00", font=('Arial', 40))
+        self.label = tk.Label(
+            self,
+            text="00:00:00",
+            font=('Arial', 40),
+            bg="white",
+            fg="#003366",
+        )
         self.label.pack(padx=20, pady=20)
 
-        control_frame = tk.Frame(self)
+        control_frame = tk.Frame(self, bg="white")
         control_frame.pack(pady=10)
 
-        tk.Button(control_frame, text="Iniciar", width=8, command=self.start).pack(side=tk.LEFT, padx=5)
-        tk.Button(control_frame, text="Parar", width=8, command=self.stop).pack(side=tk.LEFT, padx=5)
-        tk.Button(control_frame, text="Reset", width=8, command=self.reset).pack(side=tk.LEFT, padx=5)
+        btn_opts = {
+            "width": 8,
+            "bg": "#d0e7ff",
+            "activebackground": "#a0cfff",
+        }
+
+        tk.Button(control_frame, text="Iniciar", command=self.start, **btn_opts).pack(side=tk.LEFT, padx=5)
+        tk.Button(control_frame, text="Parar", command=self.stop, **btn_opts).pack(side=tk.LEFT, padx=5)
+        tk.Button(control_frame, text="Reset", command=self.reset, **btn_opts).pack(side=tk.LEFT, padx=5)
 
     def _update(self):
         if self.running:

--- a/timer.py
+++ b/timer.py
@@ -8,30 +8,43 @@ class Timer(tk.Toplevel):
         super().__init__(master)
         self.title("Timer")
         self.resizable(False, False)
+        self.configure(bg="white")
 
         self.remaining = 0
         self.running = False
         self.after_id = None
 
-        self.label = tk.Label(self, text="00:00:00", font=('Arial', 40))
+        self.label = tk.Label(
+            self,
+            text="00:00:00",
+            font=('Arial', 40),
+            bg="white",
+            fg="#003366",
+        )
         self.label.pack(padx=20, pady=20)
 
-        input_frame = tk.Frame(self)
+        input_frame = tk.Frame(self, bg="white")
         input_frame.pack(pady=5)
 
         self.minutes_var = tk.StringVar(value="0")
         self.seconds_var = tk.StringVar(value="0")
 
-        tk.Entry(input_frame, textvariable=self.minutes_var, width=3, justify='center').pack(side=tk.LEFT)
-        tk.Label(input_frame, text=":").pack(side=tk.LEFT)
-        tk.Entry(input_frame, textvariable=self.seconds_var, width=3, justify='center').pack(side=tk.LEFT)
+        tk.Entry(input_frame, textvariable=self.minutes_var, width=3, justify='center', bg='white').pack(side=tk.LEFT)
+        tk.Label(input_frame, text=":", bg="white").pack(side=tk.LEFT)
+        tk.Entry(input_frame, textvariable=self.seconds_var, width=3, justify='center', bg='white').pack(side=tk.LEFT)
 
-        control_frame = tk.Frame(self)
+        control_frame = tk.Frame(self, bg="white")
         control_frame.pack(pady=10)
 
-        tk.Button(control_frame, text="Iniciar", width=8, command=self.start).pack(side=tk.LEFT, padx=5)
-        tk.Button(control_frame, text="Parar", width=8, command=self.stop).pack(side=tk.LEFT, padx=5)
-        tk.Button(control_frame, text="Reset", width=8, command=self.reset).pack(side=tk.LEFT, padx=5)
+        btn_opts = {
+            "width": 8,
+            "bg": "#d0e7ff",
+            "activebackground": "#a0cfff",
+        }
+
+        tk.Button(control_frame, text="Iniciar", command=self.start, **btn_opts).pack(side=tk.LEFT, padx=5)
+        tk.Button(control_frame, text="Parar", command=self.stop, **btn_opts).pack(side=tk.LEFT, padx=5)
+        tk.Button(control_frame, text="Reset", command=self.reset, **btn_opts).pack(side=tk.LEFT, padx=5)
 
     def _update(self):
         if self.running and self.remaining > 0:


### PR DESCRIPTION
## Summary
- aplica esquema de cores azul e branco na tela principal
- ajusta cores da calculadora
- ajusta cores do timer
- ajusta cores do cronômetro

## Testing
- `python3 -m py_compile app.py calculator.py timer.py stopwatch.py`

------
https://chatgpt.com/codex/tasks/task_e_6840ca492c58832a8a050fad3071603d