### PR TITLE
Fix path join for ffmpeg conversion

### DIFF
--- a/node_modules/pocketsphinx-stt/convert-to-audio/index.js
+++ b/node_modules/pocketsphinx-stt/convert-to-audio/index.js
@@ -1,0 +1,64 @@
+"use strict";
+
+// originally from https://github.com/OpenNewsLabs/autoEdit_2/blob/master/lib/interactive_transcription_generator/transcriber/convert_to_audio.js
+
+/**
+ * @module convertToAudio
+ * @description Converts video or audio file into `.wav` (or any ffmpeg supported input)
+ * takes in input file, output destination file, and returns a promise.
+ * It converts into an audio file that meets the specs for STT services
+ * @requires fluent-ffmpeg
+ * @requires ffmpeg-static-electron
+ */
+const path = require('path');
+
+const ffmpegBin = require('ffmpeg-static-electron');
+
+const ffmpeg = require('fluent-ffmpeg');
+
+const ffmpegBinPath = ffmpegBin.path;
+ffmpeg.setFfmpegPath(ffmpegBinPath);
+/**
+ * Adding an helper function to force the file extension to be `.wav`
+ * this also allows the file extension in output file name/path to be optional
+ * @param {string} path - path to an audio file
+ */
+
+function wavFileExtension(filePath) {
+  let audioFileOutputPath = filePath; // https://nodejs.org/api/path.html#path_path_parse_path
+
+  const pathParsed = path.parse(audioFileOutputPath);
+
+  if (pathParsed.ext !== '.wav') {
+    audioFileOutputPath = path.join(pathParsed.dir, `${pathParsed.name}.wav`);
+  }
+
+  return audioFileOutputPath;
+}
+/**
+ * @function convertToAudio
+ * @param {string} file -  path to audio or viceo file to convert to wav
+ * @param {string} audioFileOutput - path to output wav audio file - needs to have .wav extension
+ * @returns {callback} callback - callback to return audio file path as string.
+ */
+
+
+function convertToAudio(file, audioFileOutput) {
+  // optional output file 
+  let audioFileOutputName = audioFileOutput;
+
+  if (!audioFileOutputName) {
+    audioFileOutputName = file;
+  }
+
+  const audioFileOutputPath = wavFileExtension(audioFileOutputName);
+  return new Promise((resolve, reject) => {
+    ffmpeg(file).noVideo().audioCodec('pcm_s16le').audioChannels(1).audioFrequency(16000).output(audioFileOutputPath).on('end', () => {
+      resolve(audioFileOutputPath);
+    }).on('error', err => {
+      reject(err);
+    }).run();
+  });
+}
+
+module.exports = convertToAudio;


### PR DESCRIPTION
## Summary
- tweak wavFileExtension logic inside pocketsphinx `convert-to-audio`

## Testing
- `npm start` *(fails: server requires manual requests)*
- `node -e "const convert=require('./node_modules/pocketsphinx-stt/convert-to-audio'); convert('testgen.mp3').then(o=>console.log('out:',o)).catch(e=>console.error(e));"`

------
https://chatgpt.com/codex/tasks/task_e_6840e3edb4c0832aa0d6bf172f715731