### PR TITLE
Add export button for reinforcement model

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,12 @@ Para transcrever um vídeo do YouTube, cole o link no campo **Transcrever YouTub
 
 ## Jogo da Velha
 
-O diretório `tic-tac-toe` contém um pequeno jogo da velha em HTML, CSS e JavaScript. Abra o arquivo `index.html` em um navegador para jogar contra outro participante.
+O diretório `tic-tac-toe` contém um pequeno jogo da velha em HTML, CSS e JavaScript com um agente de aprendizado por reforço. Abra o arquivo `index.html` em um navegador para iniciar o treino. Após um tempo de treino você pode exportar o algoritmo clicando em **Exportar Algoritmo**.
+
+### Reutilizando o modelo treinado
+
+1. Treine o agente no arquivo `tic-tac-toe/index.html` até que os resultados estejam satisfatórios.
+2. Clique em **Exportar Algoritmo** para baixar o arquivo `qtable.json` com a tabela Q aprendida.
+3. Guarde esse arquivo em um local seguro.
+4. Quando quiser reutilizar o modelo, copie `qtable.json` de volta para o diretório `tic-tac-toe` antes de abrir `index.html` novamente.
+5. Ao carregar a página o script lerá automaticamente o arquivo e continuará o treinamento a partir dos valores salvos.

--- a/tic-tac-toe/index.html
+++ b/tic-tac-toe/index.html
@@ -16,6 +16,7 @@
     <p>Empates: <span id="draws">0</span></p>
   </div>
   <button id="start-stop">Iniciar Treino</button>
+  <button id="export-btn">Exportar Algoritmo</button>
   <canvas id="chart" width="400" height="200"></canvas>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="script.js"></script>

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -4,6 +4,7 @@ const qWinsEl = document.getElementById('q-wins');
 const rWinsEl = document.getElementById('random-wins');
 const drawsEl = document.getElementById('draws');
 const startBtn = document.getElementById('start-stop');
+const exportBtn = document.getElementById('export-btn');
 const ctx = document.getElementById('chart').getContext('2d');
 
 let board;
@@ -17,6 +18,27 @@ const qTable = {};
 const epsilon = 0.2;
 const alpha = 0.3;
 const gamma = 0.9;
+
+async function loadQTable() {
+  try {
+    const res = await fetch('qtable.json');
+    if (res.ok) {
+      const data = await res.json();
+      Object.assign(qTable, data);
+    }
+  } catch (e) {
+    console.warn('Nenhuma tabela Q prévia encontrada');
+  }
+}
+
+function exportQTable() {
+  const dataStr = 'data:text/json;charset=utf-8,' +
+    encodeURIComponent(JSON.stringify(qTable));
+  const dl = document.createElement('a');
+  dl.setAttribute('href', dataStr);
+  dl.setAttribute('download', 'qtable.json');
+  dl.click();
+}
 
 const chart = new Chart(ctx, {
   type: 'line',
@@ -162,4 +184,6 @@ startBtn.addEventListener('click', () => {
   if (running) trainingLoop();
 });
 
-renderBoard();
+exportBtn.addEventListener('click', exportQTable);
+
+loadQTable().then(renderBoard);


### PR DESCRIPTION
## Summary
- add **Exportar Algoritmo** button in Tic-Tac-Toe interface
- implement load and export logic for the Q-table
- document how to reuse the trained model in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68505ddb24a4832ab345296519785200