### PR TITLE
Add manual Q-Table loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ O diretório `tic-tac-toe` contém um pequeno jogo da velha em HTML, CSS e JavaS
 1. Treine o agente no arquivo `tic-tac-toe/index.html` até que os resultados estejam satisfatórios.
 2. Clique em **Exportar Algoritmo** para baixar o arquivo `qtable.json` com a tabela Q aprendida.
 3. Guarde esse arquivo em um local seguro.
-4. Quando quiser reutilizar o modelo, copie `qtable.json` de volta para o diretório `tic-tac-toe` antes de abrir `index.html` novamente.
-5. Ao carregar a página o script lerá automaticamente o arquivo e continuará o treinamento a partir dos valores salvos.
+4. Quando quiser reutilizar o modelo, abra `index.html` e use o botão **Carregar Q-Table** para selecionar o arquivo `qtable.json` salvo.
+5. Após o carregamento o treino continuará a partir dos valores salvos.

--- a/tic-tac-toe/index.html
+++ b/tic-tac-toe/index.html
@@ -17,6 +17,10 @@
   </div>
   <button id="start-stop">Iniciar Treino</button>
   <button id="export-btn">Exportar Algoritmo</button>
+  <div id="qtable-loader">
+    <input type="file" id="qtable-file" accept="application/json" />
+    <button id="load-qtable">Carregar Q-Table</button>
+  </div>
   <canvas id="chart" width="400" height="200"></canvas>
   <h2>Q-Table Carregada</h2>
   <pre id="qtable-display"></pre>

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -5,6 +5,8 @@ const rWinsEl = document.getElementById('random-wins');
 const drawsEl = document.getElementById('draws');
 const startBtn = document.getElementById('start-stop');
 const exportBtn = document.getElementById('export-btn');
+const fileInput = document.getElementById('qtable-file');
+const loadBtn = document.getElementById('load-qtable');
 const ctx = document.getElementById('chart').getContext('2d');
 
 let board;
@@ -19,24 +21,22 @@ const epsilon = 0.2;
 const alpha = 0.3;
 const gamma = 0.9;
 
-async function loadQTable() {
-  try {
-    const res = await fetch('qtable.json');
-    if (res.ok) {
-      const data = await res.json();
+function loadQTableFromFile(file) {
+  const reader = new FileReader();
+  reader.onload = e => {
+    try {
+      const data = JSON.parse(e.target.result);
       Object.assign(qTable, data);
       const qDisplay = document.getElementById('qtable-display');
       if (qDisplay) {
         qDisplay.textContent = JSON.stringify(qTable, null, 2);
       }
+    } catch (err) {
+      console.error('Erro ao carregar Q-Table', err);
+      alert('Arquivo de Q-Table inválido');
     }
-  } catch (e) {
-    console.warn('Nenhuma tabela Q prévia encontrada');
-    const qDisplay = document.getElementById('qtable-display');
-    if (qDisplay) {
-      qDisplay.textContent = 'Nenhuma tabela Q prévia encontrada';
-    }
-  }
+  };
+  reader.readAsText(file);
 }
 
 function exportQTable() {
@@ -193,5 +193,10 @@ startBtn.addEventListener('click', () => {
 });
 
 exportBtn.addEventListener('click', exportQTable);
+loadBtn.addEventListener('click', () => {
+  if (fileInput.files.length > 0) {
+    loadQTableFromFile(fileInput.files[0]);
+  }
+});
 
-loadQTable().then(renderBoard);
+renderBoard();


### PR DESCRIPTION
## Summary
- add button and file input to load a Q-Table file manually
- update the script to load the file using FileReader
- document new Q-Table loading method in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850622ec120832aa1d34223d18d90b2