### PR TITLE
Add summary info for Q-table

### DIFF
--- a/tic-tac-toe/index.html
+++ b/tic-tac-toe/index.html
@@ -23,6 +23,8 @@
   </div>
   <canvas id="chart" width="400" height="200"></canvas>
   <h2>Q-Table Carregada</h2>
+  <h3>Resumo</h3>
+  <pre id="qtable-info"></pre>
   <pre id="qtable-display"></pre>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="script.js"></script>

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -21,6 +21,26 @@ const epsilon = 0.2;
 const alpha = 0.3;
 const gamma = 0.9;
 
+function updateQTableInfo() {
+  const infoEl = document.getElementById('qtable-info');
+  if (!infoEl) return;
+  const states = Object.keys(qTable);
+  let totalValues = 0;
+  let sum = 0;
+  let min = Infinity;
+  let max = -Infinity;
+  states.forEach(s => {
+    qTable[s].forEach(v => {
+      totalValues++;
+      sum += v;
+      if (v < min) min = v;
+      if (v > max) max = v;
+    });
+  });
+  const avg = totalValues ? sum / totalValues : 0;
+  infoEl.textContent = `Estados: ${states.length}\nValores: ${totalValues}\nMédia: ${avg.toFixed(2)}\nMin: ${min === Infinity ? 0 : min.toFixed(2)}\nMax: ${max === -Infinity ? 0 : max.toFixed(2)}`;
+}
+
 function loadQTableFromFile(file) {
   const reader = new FileReader();
   reader.onload = e => {
@@ -31,6 +51,7 @@ function loadQTableFromFile(file) {
       if (qDisplay) {
         qDisplay.textContent = JSON.stringify(qTable, null, 2);
       }
+      updateQTableInfo();
     } catch (err) {
       console.error('Erro ao carregar Q-Table', err);
       alert('Arquivo de Q-Table inválido');
@@ -136,6 +157,7 @@ function updateQ(states, reward) {
     qTable[state][action] += alpha * (reward + gamma * nextMax - qTable[state][action]);
     reward *= gamma;
   }
+  updateQTableInfo();
 }
 
 function delay(ms) { return new Promise(res => setTimeout(res, ms)); }

--- a/tic-tac-toe/style.css
+++ b/tic-tac-toe/style.css
@@ -36,3 +36,14 @@ body {
   max-width: 600px;
   margin: 0 auto;
 }
+
+#qtable-info,
+#qtable-display {
+  text-align: left;
+  max-height: 300px;
+  overflow: auto;
+  margin: 0 auto 20px;
+  border: 1px solid #ccc;
+  padding: 10px;
+  width: 90%;
+}


### PR DESCRIPTION
## Summary
- show simplified Q-table statistics in the Tic-Tac-Toe interface
- compute stats for loaded and updated Q-tables
- style new output area

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68506321abb8832a993a409fbb772a42