### PR TITLE
Add training speed control to tic-tac-toe

### DIFF
--- a/tic-tac-toe/index.html
+++ b/tic-tac-toe/index.html
@@ -17,6 +17,8 @@
   </div>
   <button id="start-stop">Iniciar Treino</button>
   <button id="export-btn">Exportar Algoritmo</button>
+  <label for="speed">Delay por passo (ms):</label>
+  <input type="number" id="speed" value="0" min="0" step="1">
   <div id="qtable-loader">
     <input type="file" id="qtable-file" accept="application/json" />
     <button id="load-qtable">Carregar Q-Table</button>

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -20,6 +20,11 @@ const qTable = {};
 const epsilon = 0.2;
 const alpha = 0.3;
 const gamma = 0.9;
+const speedInput = document.getElementById('speed');
+let stepDelay = Number(speedInput?.value) || 0;
+speedInput?.addEventListener('input', () => {
+  stepDelay = Number(speedInput.value) || 0;
+});
 
 function updateQTableInfo() {
   const infoEl = document.getElementById('qtable-info');
@@ -190,7 +195,7 @@ async function playGame() {
       break;
     }
     currentPlayer = currentPlayer === 'O' ? 'X' : 'O';
-    await delay(20);
+    await delay(stepDelay);
   }
   let result;
   if (checkWin('O')) result = 'q';
@@ -199,7 +204,7 @@ async function playGame() {
   const reward = result === 'q' ? 1 : result === 'r' ? -1 : 0.5;
   updateQ(qStates, reward);
   updateScore(result);
-  await delay(50);
+  await delay(stepDelay);
 }
 
 async function trainingLoop() {


### PR DESCRIPTION
## Summary
- add delay input in tic-tac-toe UI
- allow controlling delay between training steps in `script.js`

## Testing
- `npm install`
- `OPENAI_API_KEY=dummy npm start`

------
https://chatgpt.com/codex/tasks/task_e_685064ba4108832aade18d7703bcc05a