### PR TITLE
Enable Q-Table selection when starting AI match

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Para transcrever um vídeo do YouTube, cole o link no campo **Transcrever YouTub
 
 O diretório `tic-tac-toe` contém um pequeno jogo da velha em HTML, CSS e JavaScript com um agente de aprendizado por reforço. Abra o arquivo `index.html` em um navegador para iniciar o treino. Após um tempo de treino você pode exportar o algoritmo clicando em **Exportar Algoritmo**.
 
-Após treinar ou carregar uma Q-Table, use o botão **Jogar contra Robô** para desafiar o algoritmo treinado. Clique nas casas do tabuleiro para fazer sua jogada e o agente responderá automaticamente.
+Clique em **Jogar contra Robô** para escolher a Q-Table que o robô utilizará na partida. Após selecionar o arquivo, o agente carregará esse conhecimento e jogará sempre tentando vencer. Clique nas casas do tabuleiro para fazer sua jogada e o robô responderá automaticamente.
 
 ### Reutilizando o modelo treinado
 

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -299,9 +299,19 @@ playAiBtn.addEventListener('click', () => {
     statusEl.textContent = '';
     renderBoard();
   } else {
-    humanPlaying = true;
-    playAiBtn.textContent = 'Sair do Jogo';
-    startHumanGame();
+    // permite ao usuário escolher a Q-Table que será usada na partida
+    fileInput.value = '';
+    const handler = () => {
+      if (fileInput.files.length > 0) {
+        loadQTableFromFile(fileInput.files[0]);
+        humanPlaying = true;
+        playAiBtn.textContent = 'Sair do Jogo';
+        startHumanGame();
+      }
+      fileInput.removeEventListener('change', handler);
+    };
+    fileInput.addEventListener('change', handler, { once: true });
+    fileInput.click();
   }
 });
 


### PR DESCRIPTION
## Summary
- allow user to load a Q‑Table when clicking **Jogar contra Robô**
- update README with new instructions

## Testing
- `npm -s test`

------
https://chatgpt.com/codex/tasks/task_e_685070ba6f3c832abebde69279b335db