### PR TITLE
Fix robo starts with trained model

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Para transcrever um vídeo do YouTube, cole o link no campo **Transcrever YouTub
 
 O diretório `tic-tac-toe` contém um pequeno jogo da velha em HTML, CSS e JavaScript com um agente de aprendizado por reforço. Abra o arquivo `index.html` em um navegador para iniciar o treino. Após um tempo de treino você pode exportar o algoritmo clicando em **Exportar Algoritmo**.
 
-Clique em **Jogar contra Robô** para escolher a Q-Table que o robô utilizará na partida. Após selecionar o arquivo, o agente carregará esse conhecimento e jogará sempre tentando vencer. Clique nas casas do tabuleiro para fazer sua jogada e o robô responderá automaticamente.
+Clique em **Jogar contra Robô** para escolher a Q-Table que o robô utilizará na partida. Após selecionar o arquivo, o agente carregará esse conhecimento e fará a primeira jogada (o treinamento pressupõe que ele inicie). Em seguida clique nas casas do tabuleiro para fazer sua jogada e o robô responderá automaticamente tentando sempre vencer.
 
 ### Reutilizando o modelo treinado
 

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -179,8 +179,11 @@ function startHumanGame() {
   epsilon = EPSILON_PLAY;
   board = Array(9).fill(null);
   gameOver = false;
-  statusEl.textContent = 'Sua vez';
+  // o agente foi treinado iniciando as partidas, entao ele faz a primeira jogada
+  const aiIdx = chooseQMove(board);
+  makeMove(aiIdx, 'O');
   renderBoard(handleHumanMove);
+  statusEl.textContent = 'Sua vez';
 }
 
 async function handleHumanMove(idx) {


### PR DESCRIPTION
## Summary
- make the AI take the first move when using a trained model
- clarify README that the robot starts the match

## Testing
- `npm install`
- `npm start` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_685071a01160832a99af53fe81b0450f