### PR TITLE
Add replay support and human scoreboard

### DIFF
--- a/tic-tac-toe/index.html
+++ b/tic-tac-toe/index.html
@@ -15,6 +15,12 @@
     <p>Vitórias Robo Aleatório: <span id="random-wins">0</span></p>
     <p>Empates: <span id="draws">0</span></p>
   </div>
+  <div id="human-scoreboard" style="display:none;">
+    <p>Vitórias Jogador: <span id="player-wins">0</span></p>
+    <p>Vitórias Robô: <span id="ai-wins-player">0</span></p>
+    <p>Empates: <span id="player-draws">0</span></p>
+  </div>
+  <button id="play-again" style="display:none;">Jogar Novamente</button>
   <button id="play-ai">Jogar contra Robô</button>
   <button id="start-stop">Iniciar Treino</button>
   <button id="export-btn">Exportar Algoritmo</button>

--- a/tic-tac-toe/style.css
+++ b/tic-tac-toe/style.css
@@ -32,6 +32,10 @@ body {
   margin-bottom: 20px;
 }
 
+#human-scoreboard {
+  margin-bottom: 20px;
+}
+
 #chart {
   max-width: 600px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- vary AI moves by adding slight exploration
- show scoreboard for matches against the robot
- allow replaying a match while keeping the same model
- alternate which player starts each new game

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685073482cb4832aa1b43f923cab7c92