### PR TITLE
Add training speed slider

### DIFF
--- a/tic-tac-toe/index.html
+++ b/tic-tac-toe/index.html
@@ -26,6 +26,9 @@
   <button id="export-btn">Exportar Algoritmo</button>
   <label for="speed">Delay por passo (ms):</label>
   <input type="number" id="speed" value="0" min="0" step="1">
+  <label for="speed-multiplier">Velocidade:</label>
+  <input type="range" id="speed-multiplier" value="1" min="0.5" max="2" step="0.1">
+  <span id="speed-value">1x</span>
   <label><input type="checkbox" id="fast-mode"> Modo Turbo</label>
   <div id="qtable-loader">
     <input type="file" id="qtable-file" accept="application/json" />

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -40,6 +40,14 @@ let stepDelay = Number(speedInput?.value) || 0;
 speedInput?.addEventListener('input', () => {
   stepDelay = Number(speedInput.value) || 0;
 });
+const speedMultiplierInput = document.getElementById('speed-multiplier');
+const speedValueEl = document.getElementById('speed-value');
+let speedMultiplier = Number(speedMultiplierInput?.value) || 1;
+if (speedValueEl) speedValueEl.textContent = `${speedMultiplier}x`;
+speedMultiplierInput?.addEventListener('input', () => {
+  speedMultiplier = Number(speedMultiplierInput.value) || 1;
+  if (speedValueEl) speedValueEl.textContent = `${speedMultiplier}x`;
+});
 const fastInput = document.getElementById('fast-mode');
 let fastMode = fastInput?.checked || false;
 fastInput?.addEventListener('change', () => {
@@ -232,7 +240,9 @@ function updateQ(states, reward) {
   if (!fastMode) updateQTableInfo();
 }
 
-function delay(ms) { return new Promise(res => setTimeout(res, ms)); }
+function delay(ms) {
+  return new Promise(res => setTimeout(res, ms / speedMultiplier));
+}
 
 function startHumanGame() {
   // usa somente o conhecimento aprendido para desafiar o jogador


### PR DESCRIPTION
## Summary
- allow adjusting training speed with new range slider
- control training delay based on slider value

## Testing
- `npm install --silent`
- `npm start --silent` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_685077187600832a8e28fe25e597f0e2