### PR TITLE
Improve tic-tac-toe training

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ O diretório `tic-tac-toe` contém um pequeno jogo da velha em HTML, CSS e JavaS
 
 O algoritmo agora considera simetrias do tabuleiro ao treinar, reduzindo a quantidade de partidas necessárias para que o robô aprenda a vencer o oponente aleatório.
 
+Desde esta versão o treinamento também escolhe aleatoriamente quem inicia cada
+partida, permitindo que o modelo jogue bem mesmo quando o humano faz a
+primeira jogada.
+
 Clique em **Jogar contra Robô** para escolher a Q-Table que o robô utilizará na partida. Após selecionar o arquivo, o agente carregará esse conhecimento e fará a primeira jogada (o treinamento pressupõe que ele inicie). Em seguida clique nas casas do tabuleiro para fazer sua jogada e o robô responderá automaticamente tentando sempre vencer.
 
 ### Reutilizando o modelo treinado

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -309,7 +309,8 @@ async function handleHumanMove(idx) {
 
 async function playGame() {
   board = Array(9).fill(null);
-  currentPlayer = 'O';
+  // randomiza quem inicia para treinar a jogar de ambos os lados
+  currentPlayer = Math.random() < 0.5 ? 'O' : 'X';
   gameOver = false;
   const qStates = [];
   renderBoard();


### PR DESCRIPTION
## Summary
- randomize starting player during training
- document that training alternates who starts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850781b8f9c832abd8b68dbad35d48e