### PR TITLE
Add play/train menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Este repositório contém um experimento simples em que um agente aprende a joga
 
 ## Como usar
 
-Abra `tic-tac-toe/index.html` em um navegador moderno e acompanhe o treinamento do robô. Algumas funcionalidades disponíveis:
+Abra `tic-tac-toe/index.html` em um navegador moderno. O aplicativo possui um menu no topo com as opções **Jogar** e **Treinar**. Cada aba exibe apenas os controles necessários.
+
+No menu **Treinar** é possível acompanhar o treinamento do robô. Algumas funcionalidades disponíveis:
 
 - **Iniciar Treino** pausa ou continua o processo de aprendizagem.
 - **Velocidade** permite ajustar o intervalo entre as jogadas ou ativar o `Modo Turbo` para acelerar.
 - **Exportar Algoritmo** salva a Q-Table aprendida em um arquivo JSON.
-- **Jogar contra Robô** carrega uma Q-Table previamente exportada para desafiar o agente.
+- **Jogar contra Robô** fica disponível na aba **Jogar** e carrega uma Q-Table previamente exportada para desafiar o agente.
 
 O algoritmo leva em conta simetrias do tabuleiro para reduzir a quantidade de partidas necessárias e alterna quem inicia cada jogo durante o treinamento, garantindo que o robô saiba jogar bem dos dois lados.

--- a/tic-tac-toe/index.html
+++ b/tic-tac-toe/index.html
@@ -9,37 +9,47 @@
 <body>
   <div class="container">
     <h1>Treino Jogo da Velha</h1>
+    <nav class="menu">
+      <button id="tab-play">Jogar</button>
+      <button id="tab-train">Treinar</button>
+    </nav>
     <div id="game" class="board"></div>
     <p id="status"></p>
-    <div id="scoreboard">
-      <p>Vitórias Robo ML: <span id="q-wins">0</span></p>
-      <p>Vitórias Robo Aleatório: <span id="random-wins">0</span></p>
-      <p>Empates: <span id="draws">0</span></p>
+
+    <div id="play-section" class="section">
+      <div id="human-scoreboard" style="display:none;">
+        <p>Vitórias Jogador: <span id="player-wins">0</span></p>
+        <p>Vitórias Robô: <span id="ai-wins-player">0</span></p>
+        <p>Empates: <span id="player-draws">0</span></p>
+      </div>
+      <button id="play-again" style="display:none;">Jogar Novamente</button>
+      <button id="play-ai">Jogar contra Robô</button>
     </div>
-    <div id="human-scoreboard" style="display:none;">
-      <p>Vitórias Jogador: <span id="player-wins">0</span></p>
-      <p>Vitórias Robô: <span id="ai-wins-player">0</span></p>
-      <p>Empates: <span id="player-draws">0</span></p>
+
+    <div id="train-section" class="section">
+      <div id="scoreboard">
+        <p>Vitórias Robo ML: <span id="q-wins">0</span></p>
+        <p>Vitórias Robo Aleatório: <span id="random-wins">0</span></p>
+        <p>Empates: <span id="draws">0</span></p>
+      </div>
+      <button id="start-stop">Iniciar Treino</button>
+      <button id="export-btn">Exportar Algoritmo</button>
+      <label for="speed">Delay por passo (ms):</label>
+      <input type="number" id="speed" value="0" min="0" step="1">
+      <label for="speed-multiplier">Velocidade:</label>
+      <input type="range" id="speed-multiplier" value="1" min="0.5" max="2" step="0.1">
+      <span id="speed-value">1x</span>
+      <label><input type="checkbox" id="fast-mode"> Modo Turbo</label>
+      <div id="qtable-loader">
+        <input type="file" id="qtable-file" accept="application/json" />
+        <button id="load-qtable">Carregar Q-Table</button>
+      </div>
+      <canvas id="chart" width="400" height="200"></canvas>
+      <h2>Q-Table Carregada</h2>
+      <h3>Resumo</h3>
+      <pre id="qtable-info"></pre>
+      <pre id="qtable-display"></pre>
     </div>
-    <button id="play-again" style="display:none;">Jogar Novamente</button>
-    <button id="play-ai">Jogar contra Robô</button>
-    <button id="start-stop">Iniciar Treino</button>
-    <button id="export-btn">Exportar Algoritmo</button>
-    <label for="speed">Delay por passo (ms):</label>
-    <input type="number" id="speed" value="0" min="0" step="1">
-    <label for="speed-multiplier">Velocidade:</label>
-    <input type="range" id="speed-multiplier" value="1" min="0.5" max="2" step="0.1">
-    <span id="speed-value">1x</span>
-    <label><input type="checkbox" id="fast-mode"> Modo Turbo</label>
-    <div id="qtable-loader">
-      <input type="file" id="qtable-file" accept="application/json" />
-      <button id="load-qtable">Carregar Q-Table</button>
-    </div>
-    <canvas id="chart" width="400" height="200"></canvas>
-    <h2>Q-Table Carregada</h2>
-    <h3>Resumo</h3>
-    <pre id="qtable-info"></pre>
-    <pre id="qtable-display"></pre>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="script.js"></script>

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -14,6 +14,10 @@ const fileInput = document.getElementById('qtable-file');
 const loadBtn = document.getElementById('load-qtable');
 const ctx = document.getElementById('chart').getContext('2d');
 const playAiBtn = document.getElementById('play-ai');
+const tabPlay = document.getElementById('tab-play');
+const tabTrain = document.getElementById('tab-train');
+const playSection = document.getElementById('play-section');
+const trainSection = document.getElementById('train-section');
 
 let board;
 let currentPlayer;
@@ -419,4 +423,31 @@ playAgainBtn.addEventListener('click', () => {
   }
 });
 
+function showPlay() {
+  playSection.classList.add('active');
+  trainSection.classList.remove('active');
+  if (running) {
+    running = false;
+    startBtn.textContent = 'Iniciar Treino';
+  }
+}
+
+function showTrain() {
+  trainSection.classList.add('active');
+  playSection.classList.remove('active');
+  if (humanPlaying) {
+    humanPlaying = false;
+    epsilon = EPSILON_TRAINING;
+    playAiBtn.textContent = 'Jogar contra Rob\u00f4';
+    statusEl.textContent = '';
+    renderBoard();
+    playAgainBtn.style.display = 'none';
+    humanScoreboardEl.style.display = 'none';
+  }
+}
+
+tabPlay.addEventListener('click', showPlay);
+tabTrain.addEventListener('click', showTrain);
+
+showTrain();
 renderBoard();

--- a/tic-tac-toe/style.css
+++ b/tic-tac-toe/style.css
@@ -25,6 +25,18 @@ h1 {
   margin: 0 auto;
 }
 
+.menu {
+  margin-bottom: 20px;
+}
+
+.section {
+  display: none;
+}
+
+.section.active {
+  display: block;
+}
+
 .board {
   display: grid;
   grid-template-columns: repeat(3, 120px);


### PR DESCRIPTION
## Summary
- add "Jogar" and "Treinar" menu sections
- move training and playing elements to their areas
- switch sections with JS and hide unused controls
- update README with new instructions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68507d256218832aab541ba40938218a