### PR TITLE
Add sound effects and hide board on load

### DIFF
--- a/tic-tac-toe/index.html
+++ b/tic-tac-toe/index.html
@@ -7,14 +7,16 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <div id="credits">Created by Vini Marques</div>
+  <button id="toggle-sound">🔊</button>
   <div class="container">
     <h1>Treino Jogo da Velha</h1>
     <nav class="menu">
       <button id="tab-play">Jogar</button>
       <button id="tab-train">Treinar</button>
     </nav>
-    <div id="game" class="board"></div>
-    <p id="status"></p>
+    <div id="game" class="board" style="display:none;"></div>
+    <p id="status" style="display:none;"></p>
 
     <div id="play-section" class="section">
       <div id="human-scoreboard" style="display:none;">

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -18,6 +18,27 @@ const tabPlay = document.getElementById('tab-play');
 const tabTrain = document.getElementById('tab-train');
 const playSection = document.getElementById('play-section');
 const trainSection = document.getElementById('train-section');
+const toggleSoundBtn = document.getElementById('toggle-sound');
+
+let soundEnabled = true;
+const AudioCtx = window.AudioContext || window.webkitAudioContext;
+const audioCtx = new AudioCtx();
+
+function playTone(freq, duration) {
+  if (!soundEnabled) return;
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  osc.frequency.value = freq;
+  osc.connect(gain);
+  gain.connect(audioCtx.destination);
+  osc.start();
+  osc.stop(audioCtx.currentTime + duration / 1000);
+}
+
+function playWin() { playTone(880, 200); }
+function playLose() { playTone(220, 200); }
+function playDraw() { playTone(440, 200); }
+function playClick() { playTone(660, 100); }
 
 let board;
 let currentPlayer;
@@ -276,11 +297,13 @@ function startHumanGame() {
 
 async function handleHumanMove(idx) {
   if (gameOver || board[idx]) return;
+  playClick();
   makeMove(idx, 'X');
   renderBoard(handleHumanMove);
   if (checkWin('X')) {
     updateHumanScore('player');
     statusEl.textContent = 'Voc\u00ea venceu!';
+    playWin();
     gameOver = true;
     playAgainBtn.style.display = 'inline-block';
     aiStartsNext = !aiStartsNext;
@@ -289,6 +312,7 @@ async function handleHumanMove(idx) {
   if (board.every(Boolean)) {
     updateHumanScore('draw');
     statusEl.textContent = 'Empate';
+    playDraw();
     gameOver = true;
     playAgainBtn.style.display = 'inline-block';
     aiStartsNext = !aiStartsNext;
@@ -302,6 +326,7 @@ async function handleHumanMove(idx) {
   if (checkWin('O')) {
     updateHumanScore('ai');
     statusEl.textContent = 'Rob\u00f4 venceu!';
+    playLose();
     gameOver = true;
     playAgainBtn.style.display = 'inline-block';
     aiStartsNext = !aiStartsNext;
@@ -310,6 +335,7 @@ async function handleHumanMove(idx) {
   if (board.every(Boolean)) {
     updateHumanScore('draw');
     statusEl.textContent = 'Empate';
+    playDraw();
     gameOver = true;
     playAgainBtn.style.display = 'inline-block';
     aiStartsNext = !aiStartsNext;
@@ -428,6 +454,8 @@ playAgainBtn.addEventListener('click', () => {
 function showPlay() {
   playSection.classList.add('active');
   trainSection.classList.remove('active');
+  boardEl.style.display = 'grid';
+  statusEl.style.display = 'block';
   if (running) {
     running = false;
     startBtn.textContent = 'Iniciar Treino';
@@ -437,6 +465,8 @@ function showPlay() {
 function showTrain() {
   trainSection.classList.add('active');
   playSection.classList.remove('active');
+  boardEl.style.display = 'grid';
+  statusEl.style.display = 'block';
   if (humanPlaying) {
     humanPlaying = false;
     epsilon = EPSILON_TRAINING;
@@ -451,5 +481,7 @@ function showTrain() {
 tabPlay.addEventListener('click', showPlay);
 tabTrain.addEventListener('click', showTrain);
 
-showTrain();
-renderBoard();
+toggleSoundBtn.addEventListener('click', () => {
+  soundEnabled = !soundEnabled;
+  toggleSoundBtn.textContent = soundEnabled ? '🔊' : '🔈';
+});

--- a/tic-tac-toe/style.css
+++ b/tic-tac-toe/style.css
@@ -81,6 +81,20 @@ h1 {
   text-shadow: 0 0 10px var(--primary), 0 0 20px var(--primary);
 }
 
+#credits {
+  position: fixed;
+  top: 5px;
+  left: 5px;
+  font-size: 0.8rem;
+  color: var(--accent);
+}
+
+#toggle-sound {
+  position: fixed;
+  top: 5px;
+  right: 5px;
+}
+
 button {
   background-color: var(--primary);
   color: #fff;


### PR DESCRIPTION
## Summary
- add credit text and a button to mute/unmute
- hide board until a menu option is selected
- play tones for human clicks and game outcomes
- show board/status when switching menus

## Testing
- `node -c tic-tac-toe/script.js`

------
https://chatgpt.com/codex/tasks/task_e_685080c800f4832a9cb5a02ff2ad5879