### PR TITLE
Add distinct win/lose sounds and soften neon

### DIFF
--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -24,20 +24,49 @@ let soundEnabled = true;
 const AudioCtx = window.AudioContext || window.webkitAudioContext;
 const audioCtx = new AudioCtx();
 
-function playTone(freq, duration) {
+function playTone(freq, duration, start = audioCtx.currentTime) {
   if (!soundEnabled) return;
   const osc = audioCtx.createOscillator();
   const gain = audioCtx.createGain();
   osc.frequency.value = freq;
   osc.connect(gain);
   gain.connect(audioCtx.destination);
-  osc.start();
-  osc.stop(audioCtx.currentTime + duration / 1000);
+  osc.start(start);
+  osc.stop(start + duration / 1000);
 }
 
-function playWin() { playTone(880, 200); }
-function playLose() { playTone(220, 200); }
-function playDraw() { playTone(440, 200); }
+function playTune(notes) {
+  if (!soundEnabled) return;
+  let time = audioCtx.currentTime;
+  notes.forEach(([f, d]) => {
+    playTone(f, d, time);
+    time += d / 1000;
+  });
+}
+
+function playWin() {
+  playTune([
+    [660, 150],
+    [880, 150],
+    [1047, 300]
+  ]);
+}
+
+function playLose() {
+  playTune([
+    [440, 200],
+    [330, 200],
+    [220, 300]
+  ]);
+}
+
+function playDraw() {
+  playTune([
+    [520, 150],
+    [440, 150],
+    [520, 150]
+  ]);
+}
 function playClick() { playTone(660, 100); }
 
 let board;

--- a/tic-tac-toe/style.css
+++ b/tic-tac-toe/style.css
@@ -22,7 +22,7 @@ body {
 h1 {
   margin-top: 20px;
   color: var(--accent);
-  text-shadow: 0 0 10px var(--accent), 0 0 20px var(--accent);
+  text-shadow: 0 0 6px var(--accent), 0 0 12px var(--accent);
 }
 
 .container {
@@ -61,24 +61,24 @@ h1 {
   border: 2px solid var(--primary);
   cursor: pointer;
   transition: background-color 0.2s, transform 0.1s, box-shadow 0.3s;
-  box-shadow: 0 0 10px var(--primary), 0 0 20px var(--primary) inset;
+  box-shadow: 0 0 6px var(--primary), 0 0 12px var(--primary) inset;
   color: var(--text);
 }
 
 .cell:hover {
   background-color: var(--hover);
-  box-shadow: 0 0 15px var(--primary), 0 0 30px var(--primary) inset;
+  box-shadow: 0 0 10px var(--primary), 0 0 20px var(--primary) inset;
   transform: scale(1.05);
 }
 
 .cell.x {
   color: var(--accent);
-  text-shadow: 0 0 10px var(--accent), 0 0 20px var(--accent);
+  text-shadow: 0 0 6px var(--accent), 0 0 12px var(--accent);
 }
 
 .cell.o {
   color: var(--primary);
-  text-shadow: 0 0 10px var(--primary), 0 0 20px var(--primary);
+  text-shadow: 0 0 6px var(--primary), 0 0 12px var(--primary);
 }
 
 #credits {
@@ -105,7 +105,7 @@ button {
   cursor: pointer;
   font-size: 1rem;
   transition: background-color 0.2s, transform 0.1s, box-shadow 0.3s;
-  box-shadow: 0 0 10px var(--primary);
+  box-shadow: 0 0 6px var(--primary);
 }
 
 button:hover {
@@ -122,7 +122,7 @@ button:disabled {
   font-weight: bold;
   margin-bottom: 10px;
   color: var(--accent);
-  text-shadow: 0 0 10px var(--accent), 0 0 20px var(--accent);
+  text-shadow: 0 0 6px var(--accent), 0 0 12px var(--accent);
 }
 
 #scoreboard, #human-scoreboard {
@@ -135,7 +135,7 @@ button:disabled {
   background-color: #111;
   border-radius: 8px;
   padding: 10px;
-  box-shadow: 0 0 10px var(--primary);
+  box-shadow: 0 0 6px var(--primary);
 }
 
 #qtable-info,
@@ -149,5 +149,5 @@ button:disabled {
   background-color: #111;
   padding: 10px;
   width: 90%;
-  box-shadow: 0 0 10px var(--primary) inset;
+  box-shadow: 0 0 6px var(--primary) inset;
 }


### PR DESCRIPTION
## Summary
- add simple tune player win/lose/draw sounds
- reduce neon intensity across board and text

## Testing
- `node --check tic-tac-toe/script.js`

------
https://chatgpt.com/codex/tasks/task_e_685082359ddc832aa20fde89f147432b