### PR TITLE
Add index finger detection with counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 This is a simple web application that opens your webcam directly in the browser using the `getUserMedia` API. Click the **Open Webcam** button to grant access and start the video stream.
 
+After granting access, the page uses MediaPipe Hands to detect hand landmarks. Every time a hand is detected with only the index finger extended, the counter on the page increments.
+

--- a/index.html
+++ b/index.html
@@ -9,7 +9,12 @@
 <body>
   <h1>Webcam Viewer</h1>
   <button id="start">Open Webcam</button>
-  <video id="video" autoplay playsinline></video>
+  <div id="counter">Counter: <span id="count">0</span></div>
+  <video id="video" class="input_video" autoplay playsinline></video>
+  <canvas id="output" class="output_canvas" width="640" height="480"></canvas>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils/drawing_utils.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/camera_utils/camera_utils.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,13 +1,77 @@
 const button = document.getElementById('start');
 const video = document.getElementById('video');
+const canvasElement = document.getElementById('output');
+const canvasCtx = canvasElement.getContext('2d');
+const countElement = document.getElementById('count');
+
+let count = 0;
+let indexPose = false;
 
 button.addEventListener('click', async () => {
   try {
     const stream = await navigator.mediaDevices.getUserMedia({ video: true });
     video.srcObject = stream;
+    await video.play();
+    startDetection();
     button.disabled = true;
   } catch (err) {
     alert('Could not access webcam: ' + err.message);
   }
 });
 
+function startDetection() {
+  const hands = new Hands({
+    locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/hands/${file}`
+  });
+  hands.setOptions({
+    maxNumHands: 1,
+    modelComplexity: 1,
+    minDetectionConfidence: 0.7,
+    minTrackingConfidence: 0.5
+  });
+  hands.onResults(onResults);
+
+  const camera = new Camera(video, {
+    onFrame: async () => {
+      await hands.send({ image: video });
+    },
+    width: 640,
+    height: 480
+  });
+  camera.start();
+}
+
+function onResults(results) {
+  canvasCtx.save();
+  canvasCtx.clearRect(0, 0, canvasElement.width, canvasElement.height);
+  canvasCtx.drawImage(results.image, 0, 0, canvasElement.width, canvasElement.height);
+
+  if (results.multiHandLandmarks && results.multiHandLandmarks.length > 0) {
+    for (const landmarks of results.multiHandLandmarks) {
+      drawConnectors(canvasCtx, landmarks, HAND_CONNECTIONS, { color: '#00FF00', lineWidth: 2 });
+      drawLandmarks(canvasCtx, landmarks, { color: '#FF0000', lineWidth: 1 });
+      detectIndex(landmarks);
+    }
+  } else {
+    indexPose = false;
+  }
+
+  canvasCtx.restore();
+}
+
+function detectIndex(landmarks) {
+  const indexUp = landmarks[8].y < landmarks[6].y;
+  const middleUp = landmarks[12].y < landmarks[10].y;
+  const ringUp = landmarks[16].y < landmarks[14].y;
+  const pinkyUp = landmarks[20].y < landmarks[18].y;
+
+  if (indexUp && !middleUp && !ringUp && !pinkyUp) {
+    if (!indexPose) {
+      count++;
+      countElement.textContent = count.toString();
+      indexPose = true;
+    }
+  } else {
+    indexPose = false;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -6,7 +6,8 @@ body {
   padding: 20px;
 }
 
-video {
+video,
+canvas {
   margin-top: 20px;
   width: 100%;
   max-width: 600px;


### PR DESCRIPTION
## Summary
- show counter and overlay canvas in UI
- detect hand landmarks using MediaPipe Hands
- increment counter when only the index finger is extended
- update styles for video and canvas
- document new behaviour in README

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68533d64f6a4832a88f055a93fb88f0b