### PR TITLE
Update layout and finger detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,10 @@
   <h1>Webcam Viewer</h1>
   <button id="start">Open Webcam</button>
   <div id="counter">Counter: <span id="count">0</span></div>
-  <video id="video" class="input_video" autoplay playsinline></video>
-  <canvas id="output" class="output_canvas" width="640" height="480"></canvas>
+  <div id="viewer">
+    <video id="video" class="input_video" autoplay playsinline></video>
+    <canvas id="output" class="output_canvas" width="640" height="480"></canvas>
+  </div>
   <script src="https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils/drawing_utils.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@mediapipe/camera_utils/camera_utils.js"></script>

--- a/script.js
+++ b/script.js
@@ -64,8 +64,9 @@ function detectIndex(landmarks) {
   const middleUp = landmarks[12].y < landmarks[10].y;
   const ringUp = landmarks[16].y < landmarks[14].y;
   const pinkyUp = landmarks[20].y < landmarks[18].y;
+  const thumbUp = landmarks[4].y < landmarks[2].y;
 
-  if (indexUp && !middleUp && !ringUp && !pinkyUp) {
+  if (indexUp && !middleUp && !ringUp && !pinkyUp && !thumbUp) {
     if (!indexPose) {
       count++;
       countElement.textContent = count.toString();

--- a/style.css
+++ b/style.css
@@ -14,3 +14,17 @@ canvas {
   border: 1px solid #333;
 }
 
+#viewer {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+}
+
+#viewer video,
+#viewer canvas {
+  margin-top: 20px;
+  width: 48%;
+  max-width: 480px;
+}
+


### PR DESCRIPTION
## Summary
- place video and canvas in new container for side-by-side display
- style layout so both elements appear next to each other
- ignore raised thumb when counting index finger pose

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68533ee1eed8832aafa28812b90c81c7