### PR TITLE
Remove binary image file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 saves/
+GeoLeader_Pygame/assets/images/world_map.png

--- a/GeoLeader_Pygame/README.md
+++ b/GeoLeader_Pygame/README.md
@@ -6,7 +6,9 @@ Este projeto implementa um jogo 2D de geopolítica criado com Python e Pygame. O
 - `main.py` inicia o jogo e configura o loop principal.
 - `config.py` armazena configurações globais.
 - `src/` contém os módulos de lógica de jogo.
-- `assets/` possui imagens, sons e fontes usados na interface.
+- `assets/` possui imagens, sons e fontes usados na interface. Este repositório
+  **não** inclui o arquivo `assets/images/world_map.png`. Adicione sua própria
+  imagem ou o jogo exibirá um mapa genérico em tons de cinza.
 - `data/` guarda informações sobre países e estados iniciais.
 - `saves/` receberá arquivos de progresso.
 

--- a/GeoLeader_Pygame/src/map_renderer.py
+++ b/GeoLeader_Pygame/src/map_renderer.py
@@ -7,7 +7,7 @@ class MapRenderer:
         self.game_state = game_state
         try:
             self.map_image = pygame.image.load(MAP_IMAGE)
-        except pygame.error:
+        except (pygame.error, FileNotFoundError):
             self.map_image = pygame.Surface((800, 400))
             self.map_image.fill((30, 30, 30))
 


### PR DESCRIPTION
## Summary
- delete the `world_map.png` placeholder image
- note in the README that the repo doesn't include it
- ignore future copies of the map image in `.gitignore`

## Testing
- `pip install -r GeoLeader_Pygame/requirements.txt`
- `python GeoLeader_Pygame/main.py` *(runs until interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6855bcf05a0c832a9db617a2d0da96be