### PR TITLE
Add calendar, GameState vars and random protest event

### DIFF
--- a/GeoLeader_Pygame/main.py
+++ b/GeoLeader_Pygame/main.py
@@ -3,6 +3,7 @@ from config import WINDOW_WIDTH, WINDOW_HEIGHT, FPS
 from src.game_state import GameState
 from src.map_renderer import MapRenderer
 from src.ui import UI
+from src import events
 
 
 def main():
@@ -20,6 +21,9 @@ def main():
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_SPACE:
+                game_state.advance_time()
+                events.check_monthly_events(game_state, ui)
             ui.handle_event(event)
 
         game_state.update()

--- a/GeoLeader_Pygame/src/events.py
+++ b/GeoLeader_Pygame/src/events.py
@@ -1,4 +1,12 @@
-"""Modulo events - logica placeholder."""
+"""Gerencia eventos aleatórios do jogo."""
+
+import random
+
+
+def check_monthly_events(game_state, ui):
+    """Dispara eventos aleatórios ao avançar o mês."""
+    if random.random() < 0.1:
+        ui.show_popup("Protestos nas ruas!", on_view=lambda: print("VIEW EVENT"))
 
 
 def update(game_state):

--- a/GeoLeader_Pygame/src/game_state.py
+++ b/GeoLeader_Pygame/src/game_state.py
@@ -4,9 +4,14 @@ class GameState:
     def __init__(self):
         self.month = 1
         self.year = 2023
-        self.treasury = 2.65  # Trilhões
-        self.economy_health = 100
-        self.congress_approval = 50
+
+        # Indicadores econômicos
+        self.gdp = 2.65  # PIB em trilhões
+        self.inflation = 5.0  # Percentual
+
+        # Indicadores políticos
+        self.popularity = 50  # Popularidade do presidente
+        self.congress_approval = 50  # Aprovação no congresso
 
     def advance_time(self):
         self.month += 1


### PR DESCRIPTION
## Summary
- expand GameState with GDP, inflation and popularity
- add Popup support in UI for displaying events
- create random event system with monthly protest chance
- advance month with spacebar and trigger events
- update HUD with new variables

## Testing
- `python -m py_compile main.py src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6855c05a5d64832a88b99bc8cd75146f